### PR TITLE
Fixes multiple field identifiers/prefixes being added to subsequent criterias

### DIFF
--- a/src/firefly/domain/repository/search_criteria.py
+++ b/src/firefly/domain/repository/search_criteria.py
@@ -397,9 +397,11 @@ class BinaryOp:
             v = f':{var}'
         elif isinstance(v, (Attr, AttributeString)) and prefix is not None:
             if isinstance(v, Attr):
-                v.attr._value = f'{prefix}."{v.attr._value}"'
+                if not v.attr._value.startswith(f'{prefix}."'):
+                    v.attr._value = f'{prefix}."{v.attr._value}"'
             else:
-                v._value = f'{prefix}."{v._value}"'
+                if not v._value.startswith(f'{prefix}."'):
+                    v._value = f'{prefix}."{v._value}"'
 
         return v, params, counter
 


### PR DESCRIPTION
Only prepends a prefix identifier to a field if the field is not already prefixed.